### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,35 @@
+name: Bug report
+description: File a bug report to help us improve
+labels: ['bug']
+title: "[Bug]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug!
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Describe how to reproduce the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Paste any relevant log output.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,21 @@
+name: Chore
+description: Request maintenance or cleanup tasks
+labels: ['chore']
+title: "[Chore]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please describe the maintenance task.
+  - type: textarea
+    id: description
+    attributes:
+      label: Chore description
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,22 @@
+name: Documentation
+description: Suggest improvements or additions to documentation
+labels: ['documentation']
+title: "[Docs]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Help us improve the docs!
+  - type: textarea
+    id: docs
+    attributes:
+      label: Documentation request
+      description: Summarize the change or addition.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,34 @@
+name: Feature request
+description: Suggest an idea for this project
+labels: ['enhancement']
+title: "[Feature]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature!
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: What problem would this feature address?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/translation_request.yml
+++ b/.github/ISSUE_TEMPLATE/translation_request.yml
@@ -1,0 +1,30 @@
+name: Translation request
+description: Request new or improved translations
+labels: ['translation']
+title: "[Translation]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Let us know which language you'd like to see supported.
+  - type: input
+    id: language
+    attributes:
+      label: Language
+      description: Language you want to request
+      placeholder: e.g. Spanish
+    validations:
+      required: true
+  - type: textarea
+    id: details
+    attributes:
+      label: Details
+      description: Additional details about the translation request
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
- add GitHub issue templates for bug reports, feature requests, chores, documentation, and translation requests

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_b_6877cce67c94832e927166335a8fae2d